### PR TITLE
chore: use rustls-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ axum = { version = "0.6", features = ["headers", "macros"] }
 chrono = "0.4"
 hyper = { version = "0.14", features = ["full"] }
 jsonwebtoken = { version = "8" }
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", default-features=false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", default-features = false, features = [


### PR DESCRIPTION
It removes the openssl dependency which is generally a pain to manage