### PR TITLE
feat(errors): improve error handling with thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
 ] }
 serde = { version = "1", features = ["derive"] }
+thiserror = "2"
 tokio = { version = "1", default-features = false, features = ["time"] }
 
 [dev-dependencies]

--- a/src/axum.rs
+++ b/src/axum.rs
@@ -11,6 +11,32 @@ use serde::Deserialize;
 
 use crate::{Decoder, JwtDecoder};
 
+/// A generic struct for holding the claims of a JWT token.
+///
+/// # Example
+/// ```rust
+/// use axum::{Router, routing::get};
+/// use axum_jwt_auth::{Claims, Decoder, JwtDecoderState, LocalDecoder};
+/// use serde::{Deserialize, Serialize};
+///
+/// #[derive(Debug, Serialize, Deserialize)]
+/// struct MyClaims {
+///     sub: String,
+///     exp: u64,
+/// }
+///
+/// // Claims extractor will return a 401 if the token is invalid
+/// async fn protected(Claims(claims): Claims<MyClaims>) {
+///     println!("User {} accessed protected route", claims.sub);
+/// }
+///
+/// let decoder: Decoder = LocalDecoder::default().into();
+/// let state = JwtDecoderState { decoder };
+///
+/// let app = Router::new()
+///     .route("/protected", get(protected))
+///     .with_state(state);
+/// ```
 #[derive(Debug, Deserialize)]
 pub struct Claims<T>(pub T);
 

--- a/src/axum.rs
+++ b/src/axum.rs
@@ -12,31 +12,6 @@ use serde::Deserialize;
 use crate::{Decoder, JwtDecoder};
 
 /// A generic struct for holding the claims of a JWT token.
-///
-/// # Example
-/// ```rust
-/// use axum::{Router, routing::get};
-/// use axum_jwt_auth::{Claims, Decoder, JwtDecoderState, LocalDecoder};
-/// use serde::{Deserialize, Serialize};
-///
-/// #[derive(Debug, Serialize, Deserialize)]
-/// struct MyClaims {
-///     sub: String,
-///     exp: u64,
-/// }
-///
-/// // Claims extractor will return a 401 if the token is invalid
-/// async fn protected(Claims(claims): Claims<MyClaims>) {
-///     println!("User {} accessed protected route", claims.sub);
-/// }
-///
-/// let decoder: Decoder = LocalDecoder::default().into();
-/// let state = JwtDecoderState { decoder };
-///
-/// let app = Router::new()
-///     .route("/protected", get(protected))
-///     .with_state(state);
-/// ```
 #[derive(Debug, Deserialize)]
 pub struct Claims<T>(pub T);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,81 +11,7 @@
 //!
 //! # Example
 //!
-//! ```rust
-//! use axum::{
-//!     extract::FromRef,
-//!     response::{IntoResponse, Response},
-//!     routing::{get, post},
-//!     Json, Router,
-//! };
-//!
-//! use chrono::{Duration, Utc};
-//! use jsonwebtoken::{encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
-//! use axum_jwt_auth::{Claims, Decoder, JwtDecoderState, LocalDecoder};
-//! use serde::{Deserialize, Serialize};
-//!
-//! #[derive(Clone, FromRef)]
-//! struct AppState {
-//!     decoder: JwtDecoderState,
-//! }
-//!
-//! #[derive(Debug, Serialize, Deserialize)]
-//! pub struct MyClaims {
-//!     iat: u64,
-//!     aud: String,
-//!     exp: u64,
-//! }
-//!
-//! async fn index() -> Response {
-//!     "Hello, World!".into_response()
-//! }
-//!
-//! // Claims extractor will return a 401 if the token is invalid
-//! async fn user_info(Claims(claims): Claims<MyClaims>) -> Response {
-//!     Json(claims).into_response()
-//! }
-//!
-//! async fn login() -> Response {
-//!     let key = EncodingKey::from_rsa_pem(include_bytes!("../jwt.key")).expect("valid RSA key");
-//!     let mut header = Header::new(Algorithm::RS256);
-//!     header.kid = Some("test".to_string());
-//!
-//!     let exp = Utc::now() + Duration::hours(1);
-//!     let claims = MyClaims {
-//!         iat: 1234567890,
-//!         aud: "https://example.com".to_string(),
-//!         exp: exp.timestamp() as u64,
-//!     };
-//!
-//!     let token = encode::<MyClaims>(&header, &claims, &key).expect("token creation");
-//!
-//!     token.into_response()
-//! }
-//!
-//! #[tokio::main]
-//! async fn main() {
-//!     let keys = vec![DecodingKey::from_rsa_pem(include_bytes!("jwt.key.pub")).expect("valid public key")];
-//!     let mut validation = Validation::new(Algorithm::RS256);
-//!     // Set the audience to the expected value. Not setting this will cause the token to be invalid.
-//!     validation.set_audience(&["https://example.com"]);
-//!     let decoder: Decoder = LocalDecoder::new(keys, validation).into();
-//!     let state = AppState {
-//!         decoder: JwtDecoderState { decoder },
-//!     };
-//!
-//!     let app = Router::new()
-//!         .route("/", get(index))
-//!         .route("/user_info", get(user_info))
-//!         .route("/login", post(login))
-//!         .with_state(state);
-//!
-//!     # // Commented out to make doctests pass
-//!     # // run it on localhost:3000
-//!     # // let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
-//!     # // axum::serve(listener, app).await.unwrap();
-//! }
-//! ```
-//!
+//! For a full example, see the [examples](https://github.com/cmackenzie1/axum-jwt-auth/blob/main/examples).
 
 mod axum;
 mod local;
@@ -111,18 +37,6 @@ pub enum Error {
     Reqwest(#[from] reqwest::Error),
     #[error("JWKS refresh failed: {0}")]
     JwksRefresh(String),
-}
-
-impl From<reqwest::Error> for Error {
-    fn from(err: reqwest::Error) -> Self {
-        Self::Reqwest(err)
-    }
-}
-
-impl From<jsonwebtoken::errors::Error> for Error {
-    fn from(err: jsonwebtoken::errors::Error) -> Self {
-        Self::Jwt(err)
-    }
 }
 
 /// A generic trait for decoding JWT tokens.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,91 @@
-//! Provides a thin layer over jsonwebtoken crate to manage remote JWKS and local secret keys.
+//! A Rust library for JWT authentication with support for both local keys and remote JWKS (JSON Web Key Sets).
+//!
+//! This crate provides a flexible JWT authentication system that can:
+//! - Validate tokens using local RSA/HMAC keys
+//! - Automatically fetch and cache remote JWKS endpoints
+//! - Integrate seamlessly with the Axum web framework
+//! - Handle token validation with configurable options
+//!
+//! It builds on top of the `jsonwebtoken` crate to provide higher-level authentication primitives
+//! while maintaining full compatibility with standard JWT implementations.
+//!
+//! # Example
+//!
+//! ```rust
+//! use axum::{
+//!     extract::FromRef,
+//!     response::{IntoResponse, Response},
+//!     routing::{get, post},
+//!     Json, Router,
+//! };
+//!
+//! use chrono::{Duration, Utc};
+//! use jsonwebtoken::{encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
+//! use axum_jwt_auth::{Claims, Decoder, JwtDecoderState, LocalDecoder};
+//! use serde::{Deserialize, Serialize};
+//!
+//! #[derive(Clone, FromRef)]
+//! struct AppState {
+//!     decoder: JwtDecoderState,
+//! }
+//!
+//! #[derive(Debug, Serialize, Deserialize)]
+//! pub struct MyClaims {
+//!     iat: u64,
+//!     aud: String,
+//!     exp: u64,
+//! }
+//!
+//! async fn index() -> Response {
+//!     "Hello, World!".into_response()
+//! }
+//!
+//! // Claims extractor will return a 401 if the token is invalid
+//! async fn user_info(Claims(claims): Claims<MyClaims>) -> Response {
+//!     Json(claims).into_response()
+//! }
+//!
+//! async fn login() -> Response {
+//!     let key = EncodingKey::from_rsa_pem(include_bytes!("../jwt.key")).expect("valid RSA key");
+//!     let mut header = Header::new(Algorithm::RS256);
+//!     header.kid = Some("test".to_string());
+//!
+//!     let exp = Utc::now() + Duration::hours(1);
+//!     let claims = MyClaims {
+//!         iat: 1234567890,
+//!         aud: "https://example.com".to_string(),
+//!         exp: exp.timestamp() as u64,
+//!     };
+//!
+//!     let token = encode::<MyClaims>(&header, &claims, &key).expect("token creation");
+//!
+//!     token.into_response()
+//! }
+//!
+//! #[tokio::main]
+//! async fn main() {
+//!     let keys = vec![DecodingKey::from_rsa_pem(include_bytes!("jwt.key.pub")).expect("valid public key")];
+//!     let mut validation = Validation::new(Algorithm::RS256);
+//!     // Set the audience to the expected value. Not setting this will cause the token to be invalid.
+//!     validation.set_audience(&["https://example.com"]);
+//!     let decoder: Decoder = LocalDecoder::new(keys, validation).into();
+//!     let state = AppState {
+//!         decoder: JwtDecoderState { decoder },
+//!     };
+//!
+//!     let app = Router::new()
+//!         .route("/", get(index))
+//!         .route("/user_info", get(user_info))
+//!         .route("/login", post(login))
+//!         .with_state(state);
+//!
+//!     # // Commented out to make doctests pass
+//!     # // run it on localhost:3000
+//!     # // let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
+//!     # // axum::serve(listener, app).await.unwrap();
+//! }
+//! ```
+//!
 
 mod axum;
 mod local;
@@ -8,16 +95,22 @@ use std::sync::Arc;
 
 use jsonwebtoken::TokenData;
 use serde::de::DeserializeOwned;
+use thiserror::Error;
 
 pub use crate::axum::{AuthError, Claims, JwtDecoderState};
 pub use crate::local::LocalDecoder;
 pub use crate::remote::{RemoteJwksDecoder, RemoteJwksDecoderBuilder};
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("JWT key not found (kid: {0:?})")]
     KeyNotFound(Option<String>),
-    Jwt(jsonwebtoken::errors::Error),
-    Reqwest(reqwest::Error),
+    #[error("JWT error: {0}")]
+    Jwt(#[from] jsonwebtoken::errors::Error),
+    #[error("HTTP request error: {0}")]
+    Reqwest(#[from] reqwest::Error),
+    #[error("JWKS refresh failed: {0}")]
+    JwksRefresh(String),
 }
 
 impl From<reqwest::Error> for Error {
@@ -32,7 +125,9 @@ impl From<jsonwebtoken::errors::Error> for Error {
     }
 }
 
-/// A trait for decoding JWT tokens.
+/// A generic trait for decoding JWT tokens.
+///
+/// This trait is implemented for both `LocalDecoder` and `RemoteJwksDecoder`
 pub trait JwtDecoder<T>
 where
     T: for<'de> DeserializeOwned,


### PR DESCRIPTION
- Add thiserror dependency for better error handling
- Enhance Error enum with descriptive messages using thiserror derive macro
- Add comprehensive documentation with examples for Claims and JwtDecoder
- Remove manual Error implementations in favor of #[from] derives
- Add new JwksRefresh error variant for better error reporting