### PR TITLE
feat!: Add async support and improved initialization for RemoteJwksDecoder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,12 @@ license = "MIT"
 repository = "https://github.com/cmackenzie1/axum-jwt-auth"
 
 [dependencies]
+async-trait = "0.1"
 axum = { version = "0.8", features = ["macros"] }
 axum-extra = { version = "0.10.0", features = ["typed-header"] }
 dashmap = "6.1.0"
 derive_builder = "0.20.2"
+futures = "0.3"
 jsonwebtoken = { version = "9" }
 reqwest = { version = "0.12", default-features = false, features = [
     "json",

--- a/examples/remote/remote.rs
+++ b/examples/remote/remote.rs
@@ -1,9 +1,7 @@
 use std::sync::Arc;
 
 use axum::{extract::FromRef, routing::get, Json, Router};
-use axum_jwt_auth::{
-    Claims, JwtDecoderState, RemoteJwksDecoderBuilder,
-};
+use axum_jwt_auth::{Claims, JwtDecoderState, RemoteJwksDecoderBuilder};
 use jsonwebtoken::{Algorithm, EncodingKey, Header, Validation};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -88,8 +86,6 @@ async fn main() {
     tokio::spawn(async move {
         decoder_clone.refresh_keys_periodically().await;
     });
-    // Wait for the JWKS server to start
-    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 
     // Create an app server that has the decoder as a state
     let app_server = Router::new()

--- a/src/axum.rs
+++ b/src/axum.rs
@@ -32,19 +32,26 @@ where
 
         let state = JwtDecoderState::from_ref(state);
         // `JwtDecoder::decode` decodes the token
-        let token_data = state.decoder.decode(auth.token()).map_err(|e| match e {
-            crate::Error::Jwt(e) => match e.kind() {
-                jsonwebtoken::errors::ErrorKind::ExpiredSignature => Self::Rejection::ExpiredToken,
-                jsonwebtoken::errors::ErrorKind::InvalidSignature => {
-                    Self::Rejection::InvalidSignature
-                }
-                jsonwebtoken::errors::ErrorKind::InvalidAudience => {
-                    Self::Rejection::InvalidAudience
-                }
-                _ => Self::Rejection::InvalidToken,
-            },
-            _ => Self::Rejection::InternalError,
-        })?;
+        let token_data = state
+            .decoder
+            .clone()
+            .decode(auth.token())
+            .await
+            .map_err(|e| match e {
+                crate::Error::Jwt(e) => match e.kind() {
+                    jsonwebtoken::errors::ErrorKind::ExpiredSignature => {
+                        Self::Rejection::ExpiredToken
+                    }
+                    jsonwebtoken::errors::ErrorKind::InvalidSignature => {
+                        Self::Rejection::InvalidSignature
+                    }
+                    jsonwebtoken::errors::ErrorKind::InvalidAudience => {
+                        Self::Rejection::InvalidAudience
+                    }
+                    _ => Self::Rejection::InvalidToken,
+                },
+                _ => Self::Rejection::InternalError,
+            })?;
 
         Ok(Claims(token_data.claims))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ mod remote;
 
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use jsonwebtoken::TokenData;
 use serde::de::DeserializeOwned;
 use thiserror::Error;
@@ -45,11 +46,12 @@ pub enum Error {
 /// A generic trait for decoding JWT tokens.
 ///
 /// This trait is implemented for both `LocalDecoder` and `RemoteJwksDecoder`
+#[async_trait]
 pub trait JwtDecoder<T>
 where
     T: for<'de> DeserializeOwned,
 {
-    fn decode(&self, token: &str) -> Result<TokenData<T>, Error>;
+    async fn decode(&self, token: &str) -> Result<TokenData<T>, Error>;
 }
 
 /// A type alias for a decoder that can be used as a state in an Axum application.

--- a/src/local.rs
+++ b/src/local.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use jsonwebtoken::{DecodingKey, TokenData, Validation};
 use serde::de::DeserializeOwned;
 
@@ -33,11 +34,12 @@ impl From<DecodingKey> for LocalDecoder {
     }
 }
 
+#[async_trait]
 impl<T> JwtDecoder<T> for LocalDecoder
 where
     T: for<'de> DeserializeOwned,
 {
-    fn decode(&self, token: &str) -> Result<TokenData<T>, Error> {
+    async fn decode(&self, token: &str) -> Result<TokenData<T>, Error> {
         // Try to decode the token with each key in the cache
         // If none of them work, return the error from the last one
         let mut err: Option<Error> = None;


### PR DESCRIPTION
- Make JwtDecoder trait async with decode method
- Add async_trait to support async trait methods
- Implement async initialization with Notify for RemoteJwksDecoder
- Enhance key refresh and decoding logic to handle concurrent initialization
- Update tests and examples to support async decoding
- Add async-trait and futures dependencies

BREAKING CHANGE: `decode` is now async and requires awaitng.