### PR TITLE
feat: Prevent indefinite hang in `ensure_initialized`

### DIFF
--- a/src/remote.rs
+++ b/src/remote.rs
@@ -167,6 +167,14 @@ impl RemoteJwksDecoder {
 
     /// Ensures keys are available before proceeding
     async fn ensure_initialized(&self) {
+        // If we already have keys, we're already initialized
+        if !self.keys_cache.is_empty() {
+            tracing::trace!("Key store already initialised, continuing.");
+            return;
+        }
+        
+        // If direct initialization failed, fall back to waiting for the background task
+        tracing::trace!("Waiting for background initialization to complete");
         self.initialized.notified().await;
     }
 }


### PR DESCRIPTION
**Problem:**

Requests could hang indefinitely within the `RemoteJwksDecoder::decode` method, specifically while awaiting `self.initialized.notified().await` inside `ensure_initialized`. This occurred even after the background refresh task had successfully fetched keys, populated the cache, and called `notify_waiters()`.


**Solution:**

Modify `ensure_initialized` to first check if the `keys_cache` is non-empty. If keys are already present, indicating a successful prior initialization or refresh, the function returns immediately without awaiting the `Notify` signal. The `notified().await` is now only used as a fallback mechanism if the cache is empty when the check occurs, preserving the original intent for the very first request synchronization.

This ensures that once keys are successfully loaded, subsequent requests do not block unnecessarily on the potentially unreliable notification mechanism in this context.