### PR TITLE
Add configurable TLS feature flags for reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,19 @@ description = "A simple JWT authentication middleware for Axum"
 license = "MIT"
 repository = "https://github.com/cmackenzie1/axum-jwt-auth"
 
+[features]
+default = ["rustls-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
+rustls-tls-native-roots = ["reqwest/rustls-tls-native-roots"]
+native-tls = ["reqwest/native-tls"]
+native-tls-vendored = ["reqwest/native-tls-vendored"]
+
 [dependencies]
 axum = { version = "0.8", features = ["macros"] }
 axum-extra = { version = "0.12", features = ["typed-header", "cookie"] }
 dashmap = "6.1.0"
 jsonwebtoken = { version = "10", features = ["rust_crypto"] }
-reqwest = { version = "0.12", default-features = false, features = [
-    "json",
-    "rustls-tls",
-] }
+reqwest = { version = "0.12", default-features = false, features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
 tokio = { version = "1", default-features = false, features = ["time"] }


### PR DESCRIPTION
## Summary
This change introduces configurable TLS feature flags to allow users to choose their preferred TLS implementation when using this library, rather than being locked into rustls-tls.

## Key Changes
- Added a new `[features]` section to Cargo.toml with multiple TLS options:
  - `rustls-tls` (default): Uses rustls with system roots
  - `rustls-tls-native-roots`: Uses rustls with native certificate roots
  - `native-tls`: Uses the platform's native TLS implementation
  - `native-tls-vendored`: Uses vendored native TLS
- Updated the `reqwest` dependency to remove the hardcoded `rustls-tls` feature
- TLS feature selection is now delegated to Cargo's feature resolution system

## Implementation Details
- The default feature remains `rustls-tls` to maintain backward compatibility
- Users can now opt into alternative TLS implementations by specifying features when adding this crate as a dependency
- The `reqwest` dependency now only explicitly requires the `json` feature, with TLS features being optional and controlled by this crate's feature flags

https://claude.ai/code/session_014PcmRepV7DMLBi2TnVfoPo