### PR TITLE
Update reqwest TLS feature flags to match current API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/cmackenzie1/axum-jwt-auth"
 
 [features]
 default = ["rustls-tls"]
-rustls-tls = ["reqwest/rustls-tls"]
-rustls-tls-native-roots = ["reqwest/rustls-tls-native-roots"]
+rustls-tls = ["reqwest/rustls"]
+rustls-tls-native-roots = ["reqwest/rustls-native-certs"]
 native-tls = ["reqwest/native-tls"]
 native-tls-vendored = ["reqwest/native-tls-vendored"]
 


### PR DESCRIPTION
## Summary
Updates the reqwest TLS feature flags in Cargo.toml to use the correct feature names that match the current reqwest library API.

## Changes
- Updated `rustls-tls` feature from `reqwest/rustls-tls` to `reqwest/rustls`
- Updated `rustls-tls-native-roots` feature from `reqwest/rustls-tls-native-roots` to `reqwest/rustls-native-certs`

## Details
The reqwest library has updated its feature flag naming conventions. These changes ensure that the crate's TLS feature flags correctly map to the current reqwest feature names, preventing potential build failures or feature resolution issues.

https://claude.ai/code/session_015qwwPPWt7FRypWytWaUMdf