### PR TITLE
Update dependencies and CI/CD workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -33,7 +33,7 @@ jobs:
         run: cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "axum-jwt-auth"
 version = "0.7.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 authors = ["Cole MacKenzie"]
 description = "A simple JWT authentication middleware for Axum"
 license = "MIT"
@@ -19,7 +19,7 @@ native-tls-vendored = ["reqwest/native-tls-vendored"]
 axum = { version = "0.8", features = ["macros"] }
 axum-extra = { version = "0.12", features = ["typed-header", "cookie"] }
 dashmap = "6.1.0"
-jsonwebtoken = { version = "10", features = ["rust_crypto"] }
+jsonwebtoken = { version = "11", features = ["rust_crypto"] }
 reqwest = { version = "0.13", default-features = false, features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
@@ -35,7 +35,7 @@ tokio = { version = "1", default-features = false, features = [
 ] }
 serde_json = "1"
 tracing-subscriber = "0.3.19"
-rand = { version = "0.9.0", features = ["small_rng"] }
+rand = "0.10.2"
 
 [[example]]
 name = "local"


### PR DESCRIPTION
## Summary
This PR updates the project's Rust version requirement, upgrades key dependencies, and modernizes the CI/CD workflows to use the latest versions of GitHub Actions.

## Key Changes
- **Rust version**: Bumped minimum supported Rust version from 1.85 to 1.88
- **Dependencies**:
  - `jsonwebtoken`: Updated from v10 to v11
  - `rand`: Updated from v0.9.0 (with `small_rng` feature) to v0.10.2 (without feature specification)
- **GitHub Actions**:
  - `actions/checkout`: Updated from v6 to v7
  - `codecov/codecov-action`: Updated from v6 to v7

## Notable Details
- The `rand` dependency update removes the explicit `small_rng` feature flag, suggesting the feature may no longer be necessary or has been integrated differently in v0.10.2
- All CI/CD workflow updates align with the latest stable versions of the respective GitHub Actions

https://claude.ai/code/session_01J3Fq8Sqsh832kWp2HBVmLh